### PR TITLE
Fix offset notices when creating orders.

### DIFF
--- a/inc/generate.php
+++ b/inc/generate.php
@@ -227,11 +227,15 @@ class Generate {
 		}
 
 		// add random products to order
-		for ( $i = 0; $i < rand( 1, 50 ); $i++ ) {
+		$count = ( count($product_ids) < 50 ? count($product_ids) : 50);
+		for ( $i = 0; $i < rand( 1, $count ); $i++ ) {
 			// get random product id & unset so we don't add twice
-			$key = rand(0, count($product_ids));
+			$key = rand(1, count($product_ids)) - 1;
 			$id = $product_ids[$key];
+
+			// unset item and reset array keys
 			unset($product_ids[$key]);
+			$product_ids = array_values($product_ids);
 
 			$quantities = apply_filters('wc_cyclone_order_items_count', [
 				1 => 50,


### PR DESCRIPTION
Hey Bryce! Thanks for making this great tool.

I was creating orders for one of my test shops (`wp cyclone orders 100`) and noticed I was getting a lot of offset notices.

Realized there were a couple reasons for this:

1) I had less than 50 products, so the `for ( $i = 0; $i < rand( 1, 50 ); $i++ ) {` loop would sometimes run after all the products had been unset.

2) The $product_ids weren't being rekeyed after an item was reset, so the random $key would sometimes be for a missing in the $product_ids array. This was fixed by `$product_ids = array_values($product_ids)`.

3) `$key = rand(0, count($product_ids))` would sometimes create a $key not in array because array is keyed at 0, and count starts at 1. i.e. if array had 15 items array is [0,...14] whereas count = 15.

I believe everything is fixed, but definitely check I didn't introduce some other bug!

